### PR TITLE
Limit types of source resources to those of the destinations

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,8 +36,8 @@ func action(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	srcs := filter(changes, del)
-	dests := filter(changes, create)
+	dests := filterByAction(changes, create)
+	srcs := filterByDestinationResourceTypes(filterByAction(changes, del), dests)
 
 	moves := make(map[Resource]Resource)
 	for len(srcs) > 0 && len(dests) > 0 {

--- a/planner.go
+++ b/planner.go
@@ -65,10 +65,25 @@ func changes(args []string) ([]ResChange, error) {
 	return changes.ResChanges, nil
 }
 
-func filter(resources []ResChange, action changeAction) map[Resource]bool {
+func filterByAction(resources []ResChange, action changeAction) map[Resource]bool {
 	set := make(map[Resource]bool)
 	for _, res := range resources {
 		if reflect.DeepEqual(res.Change.Actions, []changeAction{action}) {
+			set[Resource{res.Address, res.Type}] = true
+		}
+	}
+	return set
+}
+
+func filterByDestinationResourceTypes(sourceResources map[Resource]bool, destResources map[Resource]bool) map[Resource]bool {
+	set := make(map[Resource]bool)
+	types := make(map[string]bool)
+	for res := range destResources {
+		types[res.Type] = true
+	}
+
+	for res := range sourceResources {
+		if types[res.Type] {
 			set[Resource{res.Address, res.Type}] = true
 		}
 	}

--- a/planner_test.go
+++ b/planner_test.go
@@ -103,13 +103,13 @@ func TestFilter(t *testing.T) {
 	want := make(map[Resource]bool)
 	want[Resource{"null_resource.create", "null_resource"}] = true
 
-	if got := filter(resources, create); !reflect.DeepEqual(got, want) {
+	if got := filterByAction(resources, create); !reflect.DeepEqual(got, want) {
 		t.Errorf("changes() = %v, want %v", got, want)
 	}
 
 	want = make(map[Resource]bool)
 	want[Resource{"null_resource.delete", "null_resource"}] = true
-	if got := filter(resources, del); !reflect.DeepEqual(got, want) {
+	if got := filterByAction(resources, del); !reflect.DeepEqual(got, want) {
 		t.Errorf("changes() = %v, want %v", got, want)
 	}
 }
@@ -135,5 +135,26 @@ func prepareState(dir string, content string, t *testing.T) {
 	}
 	if err := terraformExec([]string{}, "apply", "-auto-approve"); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestFilterByDestinationResourceTypes(t *testing.T) {
+	resSrc1 := Resource{Address: "null_resource.resource_alpha", Type: "null_resource"}
+	resSrc2 := Resource{Address: "null_resource.resource_beta", Type: "another_type"}
+	resDest1 := Resource{Address: "null_resource.resource_gamma", Type: "null_resource"}
+	resDest2 := Resource{Address: "null_resource.resource_delta", Type: "new_type"}
+
+	sourceResources := make(map[Resource]bool)
+	sourceResources[resSrc1] = true
+	sourceResources[resSrc2] = true
+	destResources := make(map[Resource]bool)
+	destResources[resDest1] = true
+	destResources[resDest2] = true
+
+	want := make(map[Resource]bool)
+	want[resSrc1] = true
+
+	if got := filterByDestinationResourceTypes(sourceResources, destResources); !reflect.DeepEqual(got, want) {
+		t.Errorf("filterByDestinationResourceTypes() = %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
This prevents showing some resources which cannot be moved as they are
intended to destroy by the user.