### PR TITLE
Make lists searchable and add key mapping to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ terraform-state-mover -- -var-file=variables.tfvars  # using variable files
 *Hint:*
 If terraform-state-mover is used with the [Google Cloud Platform provider](https://www.terraform.io/docs/providers/google/index.html) and remote state, it is recommended to use `--delay=2s`, otherwise API rate limits error might occur.
 
+## Key mapping
+| Key | Action    |
+|-----|-----------|
+| ⏎   | Select    |
+| ↓   | Next      |
+| ↑   | Previous  |
+| →   | Page Down |
+| ←   | Page Up   |
+
 ## Demo
 
 ![](demo.gif)


### PR DESCRIPTION
This PR enables the search functionality of promptui.Select. 

- The search functions just filter the resource addresses with `strings.Contains(address, searchTerm)`.
- The prompt now defaults to search mode. So users can either directly filter by entering a search term or select an entry via the arrow keys. The only downside to this is, that the key mapping is not displayed as part of the prompt anymore. That's why I added the key mapping to `README.md`.