### PR TITLE
Print terraform state mv commands on interrupt

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/manifoldco/promptui"
 	"github.com/urfave/cli/v2"
 	"log"
 	"os"
@@ -76,6 +77,12 @@ func action(ctx *cli.Context) error {
 	for len(srcs) > 0 && len(dests) > 0 {
 		src, dest, err := prompt(srcs, dests)
 		if err != nil {
+			if err == promptui.ErrInterrupt && len(moves) > 0 {
+				fmt.Println("Interrupted. These moves would have been executed based on your selections:")
+				for src, dest := range moves {
+					fmt.Printf("  terraform state mv '%s' '%s'\n", src.Address, dest.Address)
+				}
+			}
 			return err
 		}
 		if reflect.DeepEqual(src, Resource{}) {


### PR DESCRIPTION
When mapping a large number of resources mistakes can happen. Currently, if you abort `terraform-state-mover` all current mappings are lost. With these changes `terraform-state-mover` will print the `terraform state mv` commands for all the mappings that were already selected. The user can then choose to remove the faulty mappings and run the fixed commands himself.

Example output:
> Interrupted. These moves would have been executed based on your selections:
>   terraform state mv 'openstack_networking_port_v2.this[0]' 'module.vm[0].openstack_networking_port_v2.this'
>   terraform state mv 'openstack_networking_port_v2.this[1]' 'module.vm[1].openstack_networking_port_v2.this'
>   terraform state mv 'openstack_compute_instance_v2.this[0]' 'module.vm[1].openstack_compute_instance_v2.this'
> 2021/07/14 14:49:24 ^C