### PR TITLE
Update Actions, and add a workaround for some old terraform versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -197,8 +197,25 @@ jobs:
       - name: Get dependencies
         run: go get -v -t -d ./...
 
+      # Making a special case for old versions of terraform, to ignore a revoked
+      # GPG key from Hashicorp that is trusted by old versions of terraform.
+      # https://discuss.hashicorp.com/t/terraform-updates-for-hcsec-2021-12/23570
       - name: Test
-        run: go test -v ./...
+        run: |
+          case ${{ matrix.terraform }} in
+            # For the old versions of terraform that are patched, run the tests as normal.
+            0.11.15 | 0.12.31 | 0.13.7 )
+              go test -v ./...
+              ;;
+            # For the old unpatched versions, skip verifying plugins in the init step.
+            0.10.* | 0.11.* | 0.12.* | 0.13.* )
+              TF_CLI_ARGS_init="-verify-plugins=false" go test -v ./...
+              ;;
+            # For all other versions, run the tests as normal.
+            * )
+              go test -v ./...
+              ;;
+          esac
 
       - name: Build
         run: go build -v .

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,6 @@ name: Check
 on: [push, pull_request]
 jobs:
 
-
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -10,7 +9,7 @@ jobs:
     steps:
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.17
         id: go
@@ -19,12 +18,12 @@ jobs:
         run: wget https://releases.hashicorp.com/terraform/1.2.2/terraform_1.2.2_linux_amd64.zip -O /tmp/terraform.zip && sudo unzip -o -d /usr/local/bin/ /tmp/terraform.zip
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2.3.0
+        uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: v1.33
+          version: v1.50
 
       - name: Get dependencies
         run: go get -v -t -d ./...
@@ -33,9 +32,9 @@ jobs:
         run: go test -v -cover -coverprofile=coverage.txt ./...
 
       - name: Coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
-          file: ./coverage.txt
+          files: ./coverage.txt
 
   pre012:
     name: pre012
@@ -44,7 +43,7 @@ jobs:
     steps:
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.17
         id: go
@@ -53,7 +52,7 @@ jobs:
         run: wget https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_amd64.zip -O /tmp/terraform.zip && sudo unzip -o -d /usr/local/bin/ /tmp/terraform.zip
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Get dependencies
         run: go get -v -t -d ./...
@@ -62,9 +61,9 @@ jobs:
         run: go test -v -cover -coverprofile=coverage.txt ./...
 
       - name: Coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
-          file: ./coverage.txt
+          files: ./coverage.txt
 
   terraform_version_compatibility:
     name: Terraform compatibility
@@ -183,7 +182,7 @@ jobs:
     steps:
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.17
         id: go
@@ -192,7 +191,7 @@ jobs:
         run: wget https://releases.hashicorp.com/terraform/${{ matrix.terraform }}/terraform_${{ matrix.terraform }}_linux_amd64.zip -O /tmp/terraform.zip && sudo unzip -o -d /usr/local/bin/ /tmp/terraform.zip
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Get dependencies
         run: go get -v -t -d ./...
@@ -203,18 +202,22 @@ jobs:
       - name: Test
         run: |
           case ${{ matrix.terraform }} in
+
             # For the old versions of terraform that are patched, run the tests as normal.
             0.11.15 | 0.12.31 | 0.13.7 )
               go test -v ./...
               ;;
+
             # For the old unpatched versions, skip verifying plugins in the init step.
             0.10.* | 0.11.* | 0.12.* | 0.13.* )
               TF_CLI_ARGS_init="-verify-plugins=false" go test -v ./...
               ;;
+
             # For all other versions, run the tests as normal.
             * )
               go test -v ./...
               ;;
+
           esac
 
       - name: Build


### PR DESCRIPTION
Hi, I was wanting to get more experience with Go as part of hacktoberfest, and I remembered your project that greatly saved me time a couple of years ago during a fairly large refactoring of some terraform code. I noticed the github actions were broken, so I thought I'd start there. :slightly_smiling_face: 

(And please feel free to redo any of this)

It looks like old versions of the terraform cli try to verify plugins in the `terraform init` step with a GPG key that Hashicorp has expired/revoked. More on that here:
https://discuss.hashicorp.com/t/terraform-updates-for-hcsec-2021-12/23570

I found a workaround by adding `-verify-plugins=false` to the init step for just those old versions. I added a shell case statement to the Action, that might be a bit overkill, but it does ignore just those old versions, and runs the tests like normal for the newer versions of the terraform cli.

The golangci-lint step was also giving me an error on my fork, so I bumped that and the versions of the other Actions too, just for good measure.