### PR TITLE
Update Go to 1.19, update some Actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,6 +36,11 @@ jobs:
         with:
           files: ./coverage.txt
 
+      - name: Build a snapshot with GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          args: build --snapshot
+
   pre012:
     name: pre012
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.19
         id: go
 
       - name: Install terraform
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.19
         id: go
 
       - name: Install terraform
@@ -184,7 +184,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.19
         id: go
 
       - name: Install terraform

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,17 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.19
       
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
           args: release --rm-dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.19
       
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Upgrade Go from 1.17 to 1.19
 ### Changed
 ### Deprecated
 ### Removed

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mbode/terraform-state-mover
 
-go 1.17
+go 1.19
 
 require (
 	github.com/agnivade/levenshtein v1.1.1

--- a/mover_test.go
+++ b/mover_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -17,7 +16,7 @@ resource "null_resource" "second" {}`
 
 	newTf := `resource "null_resource" "new" {}
 resource "null_resource" "second" {}`
-	if err := ioutil.WriteFile(dir+"/main.tf", []byte(newTf), 0644); err != nil {
+	if err := os.WriteFile(dir+"/main.tf", []byte(newTf), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/planner.go
+++ b/planner.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"reflect"
@@ -12,7 +11,7 @@ import (
 )
 
 func changes(cfg config, planArgs []string) ([]ResChange, error) {
-	tfPlan, err := ioutil.TempFile("", "tfplan")
+	tfPlan, err := os.CreateTemp("", "tfplan")
 	if err != nil {
 		return nil, err
 	}

--- a/planner_test.go
+++ b/planner_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -13,7 +12,7 @@ func TestCreate(t *testing.T) {
 
 	content := `resource "null_resource" "first" {}
 resource "null_resource" "second" {}`
-	if err := ioutil.WriteFile(dir+"/main.tf", []byte(content), 0644); err != nil {
+	if err := os.WriteFile(dir+"/main.tf", []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -42,7 +41,7 @@ func TestDelete(t *testing.T) {
 resource "null_resource" "second" {}`
 	prepareState(dir, content, t)
 
-	if err := ioutil.WriteFile(dir+"/main.tf", []byte("\n"), 0644); err != nil {
+	if err := os.WriteFile(dir+"/main.tf", []byte("\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -67,7 +66,7 @@ func TestNoOp(t *testing.T) {
 resource "null_resource" "second" {}`
 	prepareState(dir, content, t)
 
-	if err := ioutil.WriteFile(dir+"/main.tf", []byte(content), 0644); err != nil {
+	if err := os.WriteFile(dir+"/main.tf", []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -115,7 +114,7 @@ func TestFilter(t *testing.T) {
 }
 
 func createDir(t *testing.T) string {
-	dir, err := ioutil.TempDir("", t.Name())
+	dir, err := os.MkdirTemp("", t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +126,7 @@ func createDir(t *testing.T) string {
 }
 
 func prepareState(dir string, content string, t *testing.T) {
-	if err := ioutil.WriteFile(dir+"/main.tf", []byte(content), 0644); err != nil {
+	if err := os.WriteFile(dir+"/main.tf", []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
 	if err := terraformExec(config{}, true, []string{}, "init"); err != nil {


### PR DESCRIPTION
This is doing a few things, hope that's ok, but I did separate each step into separate commits though for easier reading.

- Update Go from 1.17 to 1.19 
  - Bump the version in go.mod and in some of the Actions
  - Made a few changes because it looks like `io/ioutil` is deprecated now. Referred to the recommended replacements in [these docs](https://pkg.go.dev/io/ioutil).
- Bump the versions of some other Actions
- Add `goreleaser build --snapshot` to the check.yml Actions
  - I just found the `--snapshot` flag while playing with goreleaser recently, and I figured it would be nice to do a dry-run of the build sometime before the publish Action runs.
  
Oh and can you add that `hacktoberfest-accepted` label (if you end up accepting this), thanks!